### PR TITLE
Fix Multithread Pooling, Reliable,  multiple 

### DIFF
--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessage.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessage.cs
@@ -9,9 +9,24 @@ namespace Forge.Networking.Messaging
 		public abstract IMessageInterpreter Interpreter { get; }
 		public abstract void Serialize(BMSByte buffer);
 		public abstract void Deserialize(BMSByte buffer);
-		public void Sent()
+		public bool IsPooled { get; set; } = false;
+		public bool IsBuffered { get; set; } = false;
+		public bool IsSent { get; set; } = false;
+
+		public virtual void Sent()
 		{
+			IsSent = true;
 			OnMessageSent?.Invoke(this);
 		}
+		public void Unbuffered()
+        {
+			IsBuffered = false;
+			OnMessageSent?.Invoke(this);
+		}
+
+		public virtual void Reset()
+        {
+
+        }
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageCodes.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageCodes.cs
@@ -43,7 +43,9 @@ namespace Forge.Networking.Messaging
 		{
 			if (!_messageTypes.TryGetValue(code, out var type))
 				throw new MessageCodeNotFoundException(code);
-			return _messagePool.Get(type);
+			var message = _messagePool.Get(type);
+			((IMessage)message).Reset();
+			return message;
 		}
 
 		public static int GetCodeFromType(Type type)
@@ -52,6 +54,14 @@ namespace Forge.Networking.Messaging
 				throw new MessageTypeNotFoundException(type);
 			return code;
 		}
+
+		public static T Instantiate<T>()
+        {
+			int code = GetCodeFromType(typeof(T));
+			T message = (T)Instantiate(code);
+			((IMessage)message).Reset();
+			return message;
+        }
 
 		public static void Clear()
 		{

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessage.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessage.cs
@@ -12,5 +12,10 @@ namespace Forge.Networking.Messaging
 		void Serialize(BMSByte buffer);
 		void Deserialize(BMSByte buffer);
 		void Sent();
+		void Unbuffered();
+		bool IsPooled { get; set; }
+		bool IsBuffered { get; set; }
+		bool IsSent { get; set; }
+		void Reset();
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/MessagePoolMulti.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/MessagePoolMulti.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace Forge.Networking.Messaging
 {
 	public class MessagePoolMulti
 	{
-		private readonly Dictionary<Type, Queue<IMessage>> _messagePools = new Dictionary<Type, Queue<IMessage>>();
+		private readonly Dictionary<Type, ConcurrentQueue<IMessage>> _messagePools = new Dictionary<Type, ConcurrentQueue<IMessage>>();
 
 		public IMessage Get(Type t)
 		{
@@ -13,7 +14,17 @@ namespace Forge.Networking.Messaging
 			if (pool.Count == 0)
 				return CreateNewMessageForPool(t, pool);
 			else
-				return pool.Dequeue();
+			{
+				// Try to dequeue, but if locked default to create new
+				IMessage item;
+				if (pool.TryDequeue(out item))
+				{
+					item.IsPooled = false;
+					item.Receipt = null;
+					return item;
+				}
+				else return CreateNewMessageForPool(t, pool);
+			}
 		}
 
 		public T Get<T>() where T : IMessage, new()
@@ -22,27 +33,37 @@ namespace Forge.Networking.Messaging
 			if (pool.Count == 0)
 				return CreateNewMessageForPool<T>(pool);
 			else
-				return (T)pool.Dequeue();
+			{
+				// Try to dequeue, but if locked default to create new
+				IMessage item;
+				if (pool.TryDequeue(out item))
+				{
+					item.IsPooled = false;
+					item.Receipt = null;
+					return (T)item;
+				}
+				else return CreateNewMessageForPool<T>(pool);
+			}
 		}
 
-		private Queue<IMessage> GetPool(Type type)
+		private ConcurrentQueue<IMessage> GetPool(Type type)
 		{
 			if (!_messagePools.TryGetValue(type, out var pool))
 			{
-				pool = new Queue<IMessage>();
+				pool = new ConcurrentQueue<IMessage>();
 				_messagePools.Add(type, pool);
 			}
 			return pool;
 		}
 
-		private T CreateNewMessageForPool<T>(Queue<IMessage> pool) where T : IMessage, new()
+		private T CreateNewMessageForPool<T>(ConcurrentQueue<IMessage> pool) where T : IMessage, new()
 		{
 			T m = new T();
 			m.OnMessageSent += Release;
 			return m;
 		}
 
-		private IMessage CreateNewMessageForPool(Type t, Queue<IMessage> pool)
+		private IMessage CreateNewMessageForPool(Type t, ConcurrentQueue<IMessage> pool)
 		{
 			IMessage m = (IMessage)Activator.CreateInstance(t);
 			m.OnMessageSent += Release;
@@ -51,7 +72,12 @@ namespace Forge.Networking.Messaging
 
 		private void Release(IMessage message)
 		{
-			Queue<IMessage> pool = GetPool(message.GetType());
+			if (message.IsPooled) return; // Message has already been returned to pool
+			if (!message.IsSent) return;	// Message has not been sent, not ready to return to pool
+			if (message.IsBuffered) return; // Message is still buffered, not ready to return to pool
+			message.IsSent = false;
+			message.IsPooled = true;
+			ConcurrentQueue<IMessage> pool = GetPool(message.GetType());
 			pool.Enqueue(message);
 		}
 	}


### PR DESCRIPTION
This fixes a number of issues with message pooling. 

1. Made the Pool system thread safe

2. When a reliable message is sent, it gets added to the resend buffer, but it is also returned to the pool when msg.sent() is called. A new buffered property manages this state, so that the message cannot be re-used until it leaves the resend buffer.

3. When a message is sent to multiple endpoints, the message was added back into the pool multiple times for each endpoint.  This may result in messages being overridden, because two successive gets from the pool, will return the same message.  The IsPooled flag, ensures the message is only added to the pool once.  

4. The Reset method in IMessage provides a mechanism for resetting the properties for a message when it is reused.  When a pooled message is reused, the previous property values are still set, if not all are overridden, these old values are transmitted which may result in unwanted behavior.  