### PR TITLE
Enhance the reliable message function

### DIFF
--- a/ForgeAlloyUnity/Assets/ForgeNetworking/DataStructures/ForgeSignature.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/DataStructures/ForgeSignature.cs
@@ -4,7 +4,7 @@ namespace Forge.DataStructures
 {
 	public class ForgeSignature : ISignature
 	{
-		private int _id;
+		protected int _id;
 
 		public ForgeSignature(ISignatureGenerator<int> generator)
 		{

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Factory/ForgeNetworkingTypeFactory.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Factory/ForgeNetworkingTypeFactory.cs
@@ -39,6 +39,10 @@ namespace Forge.Factory
 
 			Register<IChallengeMessage, ForgeConnectChallengeMessage>();
 			Register<IChallengeResponseMessage, ForgeConnectChallengeResponseMessage>();
+
+			Register<ISignatureGenerator<int>, ForgeSignatureIdGenerator>();
+			Register<IForgeEndpointRepeater, ForgeEndpointRepeater>();
+
 		}
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeEndpointRepeater.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeEndpointRepeater.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using Forge.DataStructures;
+using Forge.Factory;
+
+namespace Forge.Networking.Messaging
+{
+    public class ForgeEndpointRepeater : IForgeEndpointRepeater
+    {
+        public ISignatureGenerator<int> _generator;
+
+        // Packets that have not been received
+        private HashSet<int> _missingPackets = new HashSet<int>();
+
+        // The most recent packet that has been received
+        protected volatile int _lastPacket = -1;
+
+        private RateTracker ping = new RateTracker(100, 50, false);
+
+        public ForgeEndpointRepeater()
+        {
+            _generator = AbstractFactory.Get<INetworkTypeFactory>().GetNew<ISignatureGenerator<int>>();
+        }
+
+        public IMessageReceiptSignature GetNewMessageReceipt()
+        {
+            var receipt = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IMessageReceiptSignature>();
+            receipt.Init(_generator);
+            return receipt;
+        }
+
+        public ushort ProcessReliableSignature(int id)
+        {
+            ushort recentPackets = 0;
+
+            lock (_missingPackets)
+            {
+
+                if (id > _lastPacket)
+                {
+                    // Store any missing packets
+                    for (int i = (_lastPacket + 1); i < id; i++)
+                    {
+                        _missingPackets.Add(i);
+                    }
+
+                    _lastPacket = id;
+                }
+                else
+                {
+                    // Remove from missing packets
+                    if (!_missingPackets.Remove(id))
+                    {
+                        // Duplicate packet
+                    }
+                }
+                for (int i = 1; i <= 16; ++i)
+                {
+                    if (!this._missingPackets.Contains(id - i))
+                    {
+                        recentPackets |= (ushort)(1 << (i - 1));
+                    }
+                }
+            }
+            return recentPackets;
+        }
+
+        public void AddPing(int ms)
+        {
+            ping.UpdateStats(ms);
+        }
+
+        public int Ping { get { return ping.LastAverageValue; } }
+
+    }
+}

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageBus.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageBus.cs
@@ -154,17 +154,18 @@ namespace Forge.Networking.Messaging
 			var sig = ForgeSerializer.Instance.Deserialize<IMessageReceiptSignature>(buffer);
 			if (sig != null)
 			{
-				m.Receipt = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IMessageReceiptSignature>();
+				//m.Receipt = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IMessageReceiptSignature>();
 				m.Receipt = sig;
 				ForgeReceiptAcknowledgementMessage ack = _msgAckPool.Get();
 				ack.ReceiptSignature = sig;
+				ack.RecentPackets = _storedMessages.ProcessReliableSignature(messageSender, sig.GetHashCode());
 				SendMessage(ack, readingSocket, messageSender);
 			}
 		}
 
-		public void MessageConfirmed(EndPoint sender, IMessageReceiptSignature messageReceipt)
+		public void MessageConfirmed(EndPoint sender, IMessageReceiptSignature messageReceipt, ushort recentPackets)
 		{
-			_messageRepeater.RemoveRepeatingMessage(sender, messageReceipt);
+			_messageRepeater.RemoveRepeatingMessage(sender, messageReceipt, recentPackets);
 		}
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageReceipt.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageReceipt.cs
@@ -9,5 +9,10 @@ namespace Forge.Networking.Messaging
 		{
 
 		}
+
+		public void Init(ISignatureGenerator<int> generator)
+		{
+			_id = generator.Generate();
+		}
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageRepeater.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageRepeater.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using Forge.Factory;
 
 namespace Forge.Networking.Messaging
@@ -28,13 +29,13 @@ namespace Forge.Networking.Messaging
 
 		public void AddMessageToRepeat(IMessage message, EndPoint receiver)
 		{
-			if (!_messageRepository.Exists(receiver, message.Receipt))
+			//if (!_messageRepository.Exists(receiver, message.Receipt))
 				_messageRepository.AddMessage(message, receiver);
 		}
 
-		public void RemoveRepeatingMessage(EndPoint sender, IMessageReceiptSignature messageReceipt)
+		public void RemoveRepeatingMessage(EndPoint sender, IMessageReceiptSignature messageReceipt, ushort recentPackets)
 		{
-			_messageRepository.RemoveMessage(sender, messageReceipt);
+			_messageRepository.RemoveMessage(sender, messageReceipt, recentPackets);
 		}
 
 		public void RemoveAllFor(EndPoint receiver)

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IForgeEndpointRepeater.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IForgeEndpointRepeater.cs
@@ -1,0 +1,13 @@
+﻿using Forge.Networking.Messaging;
+using System;
+
+namespace Forge.Networking.Messaging
+{
+    public interface IForgeEndpointRepeater
+    {
+        IMessageReceiptSignature GetNewMessageReceipt();
+        ushort ProcessReliableSignature(int id);
+        void AddPing(int ms);
+        int Ping { get; }
+    }
+}

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageBus.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageBus.cs
@@ -12,6 +12,6 @@ namespace Forge.Networking.Messaging
 		IMessageReceiptSignature SendReliableMessage(IMessage message, ISocket sender, EndPoint receiver);
 		void ReceiveMessageBuffer(ISocket readingSocket, EndPoint messageSender, BMSByte messageBuffer);
 		void SetMediator(INetworkMediator mediator);
-		void MessageConfirmed(EndPoint sender, IMessageReceiptSignature messageReceipt);
+		void MessageConfirmed(EndPoint sender, IMessageReceiptSignature messageReceipt, ushort recentPackets);
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageReceipt.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageReceipt.cs
@@ -4,6 +4,6 @@ namespace Forge.Networking.Messaging
 {
 	public interface IMessageReceiptSignature : ISignature
 	{
-
+		void Init(ISignatureGenerator<int> generator);
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageRepeater.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageRepeater.cs
@@ -7,7 +7,7 @@ namespace Forge.Networking.Messaging
 		int RepeatMillisecondsInterval { get; set; }
 		void Start(INetworkMediator networkMediator);
 		void AddMessageToRepeat(IMessage message, EndPoint receiver);
-		void RemoveRepeatingMessage(EndPoint sender, IMessageReceiptSignature messageReceipt);
+		void RemoveRepeatingMessage(EndPoint sender, IMessageReceiptSignature messageReceipt, ushort recentPackets);
 		void RemoveAllFor(EndPoint receiver);
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageRepository.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageRepository.cs
@@ -8,11 +8,15 @@ namespace Forge.Networking.Messaging
 	{
 		void AddMessage(IMessage message, EndPoint sender);
 		void AddMessage(IMessage message, EndPoint sender, int ttlMilliseconds);
+		void AddMessageSend(IMessage message, EndPoint sender);
+		void AddMessageSend(IMessage message, EndPoint sender, int ttlMilliseconds);
 		void RemoveAllFor(EndPoint sender);
 		void RemoveMessage(EndPoint sender, IMessage message);
 		void RemoveMessage(EndPoint sender, IMessageReceiptSignature receipt);
+		void RemoveMessage(EndPoint sender, IMessageReceiptSignature receipt, ushort recentPackets);
 		bool Exists(EndPoint sender, IMessageReceiptSignature receipt);
 		void Iterate(MessageRepositoryIterator iterator);
 		void Clear();
+		ushort ProcessReliableSignature(EndPoint sender, int id);
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/Interpreters/ForgeReceiptAcknowledgementInterpreter.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/Interpreters/ForgeReceiptAcknowledgementInterpreter.cs
@@ -11,7 +11,7 @@ namespace Forge.Networking.Messaging.Interpreters
 		public void Interpret(INetworkMediator netHost, EndPoint sender, IMessage message)
 		{
 			var m = (ForgeReceiptAcknowledgementMessage)message;
-			netHost.MessageBus.MessageConfirmed(sender, m.ReceiptSignature);
+			netHost.MessageBus.MessageConfirmed(sender, m.ReceiptSignature, m.RecentPackets);
 			m.Sent();
 		}
 	}

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/Messages/ForgeReceiptAcknowledgementMessage.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/Messages/ForgeReceiptAcknowledgementMessage.cs
@@ -7,16 +7,19 @@ namespace Forge.Networking.Messaging.Messages
 	public class ForgeReceiptAcknowledgementMessage : ForgeMessage
 	{
 		public IMessageReceiptSignature ReceiptSignature { get; set; }
+		public ushort RecentPackets { get; set; }
 		public override IMessageInterpreter Interpreter => new ForgeReceiptAcknowledgementInterpreter();
 
 		public override void Deserialize(BMSByte buffer)
 		{
 			ReceiptSignature = ForgeSerializer.Instance.Deserialize<IMessageReceiptSignature>(buffer);
+			RecentPackets = ForgeSerializer.Instance.Deserialize<ushort>(buffer);
 		}
 
 		public override void Serialize(BMSByte buffer)
 		{
 			ForgeSerializer.Instance.Serialize(ReceiptSignature, buffer);
+			ForgeSerializer.Instance.Serialize(RecentPackets, buffer);
 		}
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/RateTracker.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/RateTracker.cs
@@ -1,0 +1,93 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Forge.Networking.Messaging
+{
+	public class RateTracker
+	{
+
+		public int averageSamples = 50;
+
+		public int LastAverageValue;
+
+		private int currentAverageSamples;
+		public float currentAverageRaw;
+
+		public bool IsTracking = false;
+
+		public bool trackSampling = false;
+		private DateTime lastUpdate;
+		private RateTracker sampling;
+
+		public RateTracker(int samples, bool tracking)
+		{
+			Init(0, samples, tracking);
+		}
+
+		public RateTracker(float startValue, int samples, bool tracking)
+		{
+			Init(startValue, samples, tracking);
+		}
+
+
+		public void Init(float startValue, int samples, bool tracking)
+		{
+			currentAverageRaw = startValue;
+			LastAverageValue = (int)startValue;
+			averageSamples = samples;
+
+			// Track stats on UpdateStats
+			if (tracking)
+			{
+				trackSampling = true;
+				sampling = new RateTracker(samples, false);
+				lastUpdate = DateTime.Now;
+			}
+		}
+
+
+		public void UpdateStats(long elapsedMs)
+		{
+			IsTracking = true;
+			float LastValue = (float)elapsedMs;
+
+			currentAverageSamples++;
+			if (currentAverageSamples > averageSamples && averageSamples != 0)
+			{
+				currentAverageRaw += (LastValue - currentAverageRaw) / (averageSamples + 1);
+			}
+			else
+			{
+				currentAverageRaw += (LastValue - currentAverageRaw) / currentAverageSamples;
+			}
+
+			int currentAverageRounded = (int)Math.Floor(currentAverageRaw);
+
+			if (LastAverageValue != currentAverageRounded)
+			{
+				LastAverageValue = currentAverageRounded;
+			}
+
+			// Track how often stats are updated
+			if (trackSampling)
+			{
+				sampling.UpdateStats((DateTime.Now - lastUpdate).Milliseconds);
+			}
+		}
+
+		public void Reset()
+		{
+			lastUpdate = DateTime.Now;
+			currentAverageRaw = 0;
+			currentAverageSamples = 0;
+			LastAverageValue = 0;
+			if (trackSampling)
+				sampling.Reset();
+		}
+
+	}
+}


### PR DESCRIPTION
The reliable message feature in Alloy currently begins resending reliable messages as soon as the message has been sent.  This creates congestion.  This change aims to alleviate this congestion by controlling the time when a message is resent and extending ack messages to also include the state of the previous 16 reliable messages. 

Features:
- Resend time is based on endpoint ping. This will delay resending message until after the expected ACK was not received.
- Each EndPoint has it's own sequence number for reliable messages. This allows the endpoint to detect lost reliable messages
- ACK Messages now include a bit array (stored in a ushort) that represent ACK's for the previous 16 messages. This feature minimises the impact of a an ACK getting lost and the full resend cycle having to be run to clear the message.   Based on some features detailed here: https://gafferongames.com/post/reliability_ordering_and_congestion_avoidance_over_udp/