### PR TITLE
Update tests for recent ForgeServerRegistryService changes

### DIFF
--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageBus.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageBus.cs
@@ -86,6 +86,7 @@ namespace Forge.Networking.Messaging
 		public IMessageReceiptSignature SendReliableMessage(IMessage message, ISocket sender, EndPoint receiver, int ttlMilliseconds = 0)
 		{
 			//message.Receipt = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IMessageReceiptSignature>();
+			message.Receipt = _messageRepeater.GetNewMessageReceipt(receiver);
 			_messageRepeater.AddMessageToRepeat(message, receiver, ttlMilliseconds);
 			SendMessage(message, sender, receiver);
 			return message.Receipt;
@@ -160,6 +161,7 @@ namespace Forge.Networking.Messaging
 				ForgeReceiptAcknowledgementMessage ack = _msgAckPool.Get();
 				ack.ReceiptSignature = sig;
 				ack.RecentPackets = _storedMessages.ProcessReliableSignature(messageSender, sig.GetHashCode());
+				//Console.WriteLine($"[{m.Receipt}] Ack Message {messageSender} {Convert.ToString(ack.RecentPackets,2)} {m.GetType().Name}");
 				SendMessage(ack, readingSocket, messageSender);
 			}
 		}

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageRepeater.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageRepeater.cs
@@ -69,5 +69,10 @@ namespace Forge.Networking.Messaging
 			_networkMediator.MessageBus.SendMessage(message,
 				_networkMediator.SocketFacade.ManagedSocket, endpoint);
 		}
+
+		public IMessageReceiptSignature GetNewMessageReceipt(EndPoint receiver)
+		{
+			return _messageRepository.GetNewMessageReceipt(receiver);
+		}
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageRepository.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageRepository.cs
@@ -90,7 +90,7 @@ namespace Forge.Networking.Messaging
 
 		public void AddMessage(IMessage message, EndPoint receiver)
 		{
-			message.Receipt = GetNewMessageReceipt(receiver);
+			//message.Receipt = GetNewMessageReceipt(receiver);
 
 			if (message.Receipt == null)
 				throw new MessageRepositoryMissingReceiptOnMessageException();
@@ -124,7 +124,7 @@ namespace Forge.Networking.Messaging
 		{
 			AddMessage(message, receiver);
 
-			var span = new TimeSpan(0, 0, 0, 0, ttlMilliseconds <= 0 ? 5000 : ttlMilliseconds);
+			var span = new TimeSpan(0, 0, 0, 0, ttlMilliseconds <= 0 ? GlobalConst.maxMessageRepeatMilliseconds : ttlMilliseconds);
 			var now = DateTime.UtcNow;
 			lock (_messagesWithTTL)
 			{
@@ -320,7 +320,7 @@ namespace Forge.Networking.Messaging
 			return _endpointRepeater[sender.IPKey()].ProcessReliableSignature(id);
 		}
 
-		private IMessageReceiptSignature GetNewMessageReceipt(EndPoint receiver)
+		public IMessageReceiptSignature GetNewMessageReceipt(EndPoint receiver)
 		{
 			if (!_endpointRepeater.ContainsKey(receiver.IPKey()))
 			{

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageRepeater.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageRepeater.cs
@@ -9,5 +9,6 @@ namespace Forge.Networking.Messaging
 		void AddMessageToRepeat(IMessage message, EndPoint receiver, int ttlMilliseconds = 0);
 		void RemoveRepeatingMessage(EndPoint sender, IMessageReceiptSignature messageReceipt, ushort recentPackets);
 		void RemoveAllFor(EndPoint receiver);
+		IMessageReceiptSignature GetNewMessageReceipt(EndPoint receiver);
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageRepository.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageRepository.cs
@@ -16,6 +16,7 @@ namespace Forge.Networking.Messaging
 		void Iterate(MessageRepositoryIterator iterator);
 		void Clear();
 		ushort ProcessReliableSignature(EndPoint sender, int id);
+		IMessageReceiptSignature GetNewMessageReceipt(EndPoint receiver);
 
 		/// <summary>
 		/// Keep track of repository purpose

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Utilities/GlobalConst.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Utilities/GlobalConst.cs
@@ -10,5 +10,6 @@ namespace Forge.ForgeAlloyUnity.Assets.ForgeNetworking.Utilities
         public const ushort defaultNatPort = 15941;
         public const string loopBackAddress = "127.0.0.1";
 		public const ushort defaultServerPort = 15945;
+		public const int maxMessageRepeatMilliseconds = 5000;
 	}
 }

--- a/ForgeTests/Networking/Messaging/MessageRepositoryTests.cs
+++ b/ForgeTests/Networking/Messaging/MessageRepositoryTests.cs
@@ -74,7 +74,10 @@ namespace ForgeTests.Networking.Messaging
 			var endpoint = A.Fake<EndPoint>();
 			message.Receipt = A.Fake<IMessageReceiptSignature>();
 			var repo = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IMessageRepository>();
-			repo.AddMessage(message, endpoint, 3);
+			// This test can be sensitive to the TTL.
+			// If it is too short when all tests are run, this test will fail.
+			// 10 fails sometimes, but 50 seems ok
+			repo.AddMessage(message, endpoint, 50);
 			Assert.IsTrue(repo.Exists(endpoint, message.Receipt));
 			Thread.Sleep(1);
 			Assert.IsTrue(repo.Exists(endpoint, message.Receipt));
@@ -86,19 +89,22 @@ namespace ForgeTests.Networking.Messaging
 			Assert.IsTrue(removed);
 		}
 
-		[Test]
-		public void AddMessageWithNegativeTTL_ShouldThrow()
-		{
-			var repo = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IMessageRepository>();
-			Assert.Throws<InvalidMessageRepositoryTTLProvided>(() => repo.AddMessage(A.Fake<IMessage>(), A.Fake<EndPoint>(), -1));
-		}
+		// Test no longer valid. The addmessage will auto-correct -ve or sero TTL
+		//[Test]
+		//public void AddMessageWithNegativeTTL_ShouldThrow()
+		//{
+		//	var repo = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IMessageRepository>();
+		//	Assert.Throws<InvalidMessageRepositoryTTLProvided>(() => repo.AddMessage(A.Fake<IMessage>(), A.Fake<EndPoint>(), -1));
+		//}
 
-		[Test]
-		public void AddMessageWithZeroTTL_ShouldThrow()
-		{
-			var repo = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IMessageRepository>();
-			Assert.Throws<InvalidMessageRepositoryTTLProvided>(() => repo.AddMessage(A.Fake<IMessage>(), A.Fake<EndPoint>(), 0));
-		}
+		// Test no longer valid. The addmessage will auto-correct -ve or sero TTL
+		// Test no longer valid
+		//[Test]
+		//public void AddMessageWithZeroTTL_ShouldThrow()
+		//{
+		//	var repo = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IMessageRepository>();
+		//	Assert.Throws<InvalidMessageRepositoryTTLProvided>(() => repo.AddMessage(A.Fake<IMessage>(), A.Fake<EndPoint>(), 0));
+		//}
 
 		// TODO:  Validate the endpoint on the messages
 		// TODO:  Validate the iterator of the messages

--- a/ForgeTests/Networking/Players/PlayerRepositoryTests.cs
+++ b/ForgeTests/Networking/Players/PlayerRepositoryTests.cs
@@ -91,17 +91,19 @@ namespace ForgeTests.Networking.Player
 			Assert.Throws<PlayerNotFoundException>(() => repo.GetPlayer(wrongEp));
 		}
 
-		[Test]
-		public void AddingPlayer_ShouldHaveGuidAssigned()
-		{
-			var initialId = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IPlayerSignature>();
-			var player = A.Fake<INetPlayer>();
-			player.Id = initialId;
-			var repo = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IPlayerRepository>();
-			repo.AddPlayer(player);
-			Assert.AreNotEqual(initialId, player.Id);
-			Assert.AreNotEqual(new Guid(), player.Id);
-		}
+		// This test is no longer valid.  The AddPlayer will check if the player already has
+		// and Id and if they do, it will not replace it
+		//[Test]
+		//public void AddingPlayer_ShouldHaveGuidAssigned()
+		//{
+		//	var initialId = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IPlayerSignature>();
+		//	var player = A.Fake<INetPlayer>();
+		//	player.Id = initialId;
+		//	var repo = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IPlayerRepository>();
+		//	repo.AddPlayer(player);
+		//	Assert.AreNotEqual(initialId, player.Id);
+		//	Assert.AreNotEqual(new Guid(), player.Id);
+		//}
 
 		[Test]
 		public void AddingPlayer_ShouldInvokeTheAddedPlayerEventAndMatch()

--- a/ForgeTests/Networking/Sockets/ConnectCycleTests.cs
+++ b/ForgeTests/Networking/Sockets/ConnectCycleTests.cs
@@ -22,7 +22,9 @@ namespace ForgeTests.Networking.Sockets
 		public void ConnectCycle()
 		{
 			var serverEngine = A.Fake<IEngineProxy>();
+			A.CallTo(() => serverEngine.CanConnectToChallenge()).Returns(true);
 			var clientEngine = A.Fake<IEngineProxy>();
+			A.CallTo(() => clientEngine.CanConnectToChallenge()).Returns(true);
 			var factory = AbstractFactory.Get<INetworkTypeFactory>();
 			var serverMediator = factory.GetNew<INetworkMediator>();
 			serverMediator.ChangeEngineProxy(serverEngine);

--- a/ForgeTests/Networking/Sockets/SocketServerFacadeTests.cs
+++ b/ForgeTests/Networking/Sockets/SocketServerFacadeTests.cs
@@ -35,9 +35,13 @@ namespace ForgeTests.Networking.Socket
 			BMSByte buffer = new BMSByte();
 			buffer.Append(new byte[] { 1 });
 			client.Send(client.EndPoint, buffer);
-			Thread.Sleep(50);
+			Thread.Sleep(200);
+			// This tests that ForgeUDPSocketServerFacade.CreatePlayer calls
+			// MessageBus.SendReliableMessage wth the parameters defined in the
+			// below test. If you change the paremeters in the CreatePlayer method
+			// Update this test accordingly. eg: if TTL changes, the below value must match
 			A.CallTo(() => netContainer.MessageBus.SendReliableMessage(A<IChallengeMessage>._,
-				A<ISocket>._, A<EndPoint>._, 1000)).MustHaveHappenedOnceExactly();
+				A<ISocket>._, A<EndPoint>._, 250)).MustHaveHappenedOnceExactly();
 			client.Close();
 			serverFacade.ShutDown();
 		}
@@ -51,18 +55,27 @@ namespace ForgeTests.Networking.Socket
 			serverFacade.StartServer(15937, 10, netContainerServer);
 			var clientFacade = AbstractFactory.Get<INetworkTypeFactory>().GetNew<ISocketClientFacade>();
 			bool done = false;
+			// The SendReliableMessage invoke is called from ForgeUDPSocketServerFacade.CreatePlayer 
+			// the MessageBus.SendReliableMessage must match below test. If you change the paremeters
+			// in the CreatePlayer method Update this test accordingly.
+			// eg: if TTL changes, the below value must match
 			A.CallTo(() => netContainerServer.MessageBus.SendReliableMessage(A<IChallengeMessage>._,
-				A<ISocket>._, A<EndPoint>._, 1000)).Invokes((ctx) =>
+				A<ISocket>._, A<EndPoint>._, 250)).Invokes((ctx) =>
 				{
 					var interpreter = new ForgeConnectChallengeInterpreter();
 					interpreter.Interpret(netContainerClient, A.Fake<EndPoint>(), (IChallengeMessage)ctx.Arguments[0]);
+					// This checks that ForgeConnectChallengeInterpreter calls SendReliableMessage with
+					// the parameters in the test.  The call currently defaults TTL to 0, which defaults the
+					// GlobalConst.maxMessageRepeatMilliseconds. If you set the TTL, ensure this matches below
 					A.CallTo(() => netContainerClient.MessageBus.SendReliableMessage(A<IChallengeResponseMessage>._,
-						A<ISocket>._, A<EndPoint>._, 1000)).MustHaveHappenedOnceExactly();
+						A<ISocket>._, A<EndPoint>._, 0)).MustHaveHappenedOnceExactly();
 					done = true;
 				});
+			A.CallTo(() => netContainerServer.EngineProxy.CanConnectToChallenge()).Returns(true);
+			A.CallTo(() => netContainerClient.EngineProxy.CanConnectToChallenge()).Returns(true);
 			var client = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IClientSocket>();
 			clientFacade.StartClient(CommonSocketBase.LOCAL_IPV4, 15937, netContainerClient);
-			Thread.Sleep(50);
+			Thread.Sleep(5000);
 			Assert.IsTrue(done);
 			client.Close();
 			serverFacade.ShutDown();
@@ -79,9 +92,11 @@ namespace ForgeTests.Networking.Socket
 			var clientFacade = AbstractFactory.Get<INetworkTypeFactory>().GetNew<ISocketClientFacade>();
 			A.CallTo(() => serverMediator.SocketFacade).Returns(serverFake);
 			A.CallTo(() => clientMediator.SocketFacade).Returns(clientFacade);
+			A.CallTo(() => serverMediator.EngineProxy.CanConnectToChallenge()).Returns(true);
+			A.CallTo(() => clientMediator.EngineProxy.CanConnectToChallenge()).Returns(true);
 			bool done = false;
 			A.CallTo(() => clientMediator.MessageBus.SendReliableMessage(A<IChallengeResponseMessage>._,
-				A<ISocket>._, A<EndPoint>._, 1000)).Invokes((ctx) =>
+				A<ISocket>._, A<EndPoint>._, 0)).Invokes((ctx) =>
 				{
 					Assert.IsTrue(((IChallengeResponseMessage)ctx.Arguments[0]).ValidateResponse());
 					var finalInterpreter = new ForgeConnectChallengeResponseInterpreter();
@@ -90,7 +105,7 @@ namespace ForgeTests.Networking.Socket
 					done = true;
 				});
 			A.CallTo(() => serverMediator.MessageBus.SendReliableMessage(A<IChallengeMessage>._,
-				A<ISocket>._, A<EndPoint>._, 1000)).Invokes((ctx) =>
+				A<ISocket>._, A<EndPoint>._, 250)).Invokes((ctx) =>
 				{
 					var interpreter = new ForgeConnectChallengeInterpreter();
 					interpreter.Interpret(clientMediator, A.Fake<EndPoint>(), (IChallengeMessage)ctx.Arguments[0]);

--- a/ForgeTests/Serialization/Serializers/ServerListingEntryArraySerializerTests.cs
+++ b/ForgeTests/Serialization/Serializers/ServerListingEntryArraySerializerTests.cs
@@ -1,4 +1,7 @@
-﻿using Forge.Networking.Sockets;
+﻿using Forge;
+using Forge.Factory;
+using Forge.Networking.Players;
+using Forge.Networking.Sockets;
 using Forge.ServerRegistry.DataStructures;
 using Forge.ServerRegistry.Serializers;
 using NUnit.Framework;
@@ -11,41 +14,55 @@ namespace ForgeTests.Serialization.Serializers
 		[Test]
 		public void SerializingServerListingEntryArray_ShouldBeEqual()
 		{
+			ForgeRegistration.Initialize();
 			ServerListingEntry[] input = new ServerListingEntry[]
 			{
 				new ServerListingEntry
 				{
-					 Address = "10.2.5.96",
-					 Port = 1265
+					Id = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IPlayerSignature>(),
+					Name = "Server1",
+					Address = "10.2.5.96",
+					Port = 1265
 				},
 				new ServerListingEntry
 				{
+					Id = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IPlayerSignature>(),
+					Name = "Server2",
 					 Address = CommonSocketBase.LOCAL_IPV4,
 					 Port = 15937
 				},
 				new ServerListingEntry
 				{
-					 Address = CommonSocketBase.LOCAL_ANY_IPV4,
-					 Port = 35719
+					Id = AbstractFactory.Get<INetworkTypeFactory>().GetNew<IPlayerSignature>(),
+					Name = "Server3",
+					Address = CommonSocketBase.LOCAL_ANY_IPV4,
+					Port = 35719
 				},
 				new ServerListingEntry
 				{
-					 Address = "76.36.45.25",
-					 Port = 555
+					Id = AbstractFactory.Get < INetworkTypeFactory >().GetNew < IPlayerSignature >(),
+					Name = "Server4",
+					Address = "76.36.45.25",
+					Port = 555
 				},
 				new ServerListingEntry
 				{
-					 Address = "255.0.2.255",
-					 Port = 983
+					Id = AbstractFactory.Get < INetworkTypeFactory >().GetNew < IPlayerSignature >(),
+					Name = "Server5",
+					Address = "255.0.2.255",
+					Port = 983
 				}
 			};
 			ServerListingEntry[] res = SerializeDeserialize(new ServerListingEntryArraySerializer(), input);
 			Assert.AreEqual(input.Length, res.Length);
 			for (int i = 0; i < input.Length; i++)
 			{
+				Assert.AreEqual(input[i].Id, res[i].Id);
+				Assert.AreEqual(input[i].Name, res[i].Name);
 				Assert.AreEqual(input[i].Address, res[i].Address);
 				Assert.AreEqual(input[i].Port, res[i].Port);
 			}
+			ForgeRegistration.Teardown();
 		}
 	}
 }

--- a/ForgeTests/ServerRegistry/Messaging/Interpreters/ForgeGetServerRegistryInterpreterTests.cs
+++ b/ForgeTests/ServerRegistry/Messaging/Interpreters/ForgeGetServerRegistryInterpreterTests.cs
@@ -14,18 +14,23 @@ namespace ForgeTests.ServerRegistry.Messaging.Interpreters
 	[TestFixture]
 	public class ForgeGetServerRegistryInterpreterTests : ForgeNetworkingTest
 	{
+		/// <summary>
+		/// The SendReliableMessage TTL parameter must match the TTL paremeter
+		/// in GetServerRegistryInterpreter.cs method Interpret.  If this
+		/// method changes, update this test accordingly
+		/// </summary>
 		[Test]
 		public void InterpretationOfGetRegistryMessage_ShouldGetCorrectPlayerList()
 		{
-			var players = new NetworkPlayer[]
+			var players = new RegisteredServer[]
 			{
-				new NetworkPlayer { EndPoint = new IPEndPoint(IPAddress.Parse(CommonSocketBase.LOCAL_IPV4), 15937), IsRegisteredServer = true },
-				new NetworkPlayer { EndPoint = new IPEndPoint(IPAddress.Parse(CommonSocketBase.LOCAL_ANY_IPV4), 15938), IsRegisteredServer = true }
+				new RegisteredServer { EndPoint = new IPEndPoint(IPAddress.Parse(CommonSocketBase.LOCAL_IPV4), 15937), IsRegisteredServer = true },
+				new RegisteredServer { EndPoint = new IPEndPoint(IPAddress.Parse(CommonSocketBase.LOCAL_ANY_IPV4), 15938), IsRegisteredServer = true }
 			};
 			var net = A.Fake<INetworkMediator>();
 			A.CallTo(() => net.PlayerRepository.Count).Returns(players.Length);
 			A.CallTo(() => net.PlayerRepository.GetEnumerator()).Returns(players.ToList().GetEnumerator());
-			A.CallTo(() => net.MessageBus.SendReliableMessage(A<IMessage>._, A<ISocket>._, A<EndPoint>._, 1000))
+			A.CallTo(() => net.MessageBus.SendReliableMessage(A<IMessage>._, A<ISocket>._, A<EndPoint>._, 0))
 				.Invokes((ctx) =>
 				{
 					Assert.IsTrue(ctx.Arguments[0] is ForgeServerRegistryMessage);
@@ -39,24 +44,24 @@ namespace ForgeTests.ServerRegistry.Messaging.Interpreters
 				});
 			var interpreter = new GetServerRegistryInterpreter();
 			interpreter.Interpret(net, players[0].EndPoint, A.Fake<IMessage>());
-			A.CallTo(() => net.MessageBus.SendReliableMessage(A<IMessage>._, A<ISocket>._, A<EndPoint>._, 1000))
+			A.CallTo(() => net.MessageBus.SendReliableMessage(A<IMessage>._, A<ISocket>._, A<EndPoint>._, 0))
 				.MustHaveHappenedOnceExactly();
 		}
 
 		[Test]
 		public void InterpretationOfGetRegistryMessageWithMixedPlayers_ShouldGetCorrectServerList()
 		{
-			var players = new NetworkPlayer[]
+			var players = new RegisteredServer[]
 			{
-				new NetworkPlayer { EndPoint = new IPEndPoint(IPAddress.Parse(CommonSocketBase.LOCAL_IPV4), 15937), IsRegisteredServer = true },
-				new NetworkPlayer { EndPoint = new IPEndPoint(IPAddress.Parse(CommonSocketBase.LOCAL_ANY_IPV4), 15938), IsRegisteredServer = true },
-				new NetworkPlayer { EndPoint = new IPEndPoint(IPAddress.Parse("5.5.5.5"), 15990), IsRegisteredServer = false },
-				new NetworkPlayer { EndPoint = new IPEndPoint(IPAddress.Parse("128.33.21.0"), 15933), IsRegisteredServer = true },
+				new RegisteredServer { EndPoint = new IPEndPoint(IPAddress.Parse(CommonSocketBase.LOCAL_IPV4), 15937), IsRegisteredServer = true },
+				new RegisteredServer { EndPoint = new IPEndPoint(IPAddress.Parse(CommonSocketBase.LOCAL_ANY_IPV4), 15938), IsRegisteredServer = true },
+				new RegisteredServer { EndPoint = new IPEndPoint(IPAddress.Parse("5.5.5.5"), 15990), IsRegisteredServer = false },
+				new RegisteredServer { EndPoint = new IPEndPoint(IPAddress.Parse("128.33.21.0"), 15933), IsRegisteredServer = true },
 			};
 			var net = A.Fake<INetworkMediator>();
 			A.CallTo(() => net.PlayerRepository.Count).Returns(players.Length);
 			A.CallTo(() => net.PlayerRepository.GetEnumerator()).Returns(players.ToList().GetEnumerator());
-			A.CallTo(() => net.MessageBus.SendReliableMessage(A<IMessage>._, A<ISocket>._, A<EndPoint>._, 1000))
+			A.CallTo(() => net.MessageBus.SendReliableMessage(A<IMessage>._, A<ISocket>._, A<EndPoint>._, 0))
 				.Invokes((ctx) =>
 				{
 					Assert.IsTrue(ctx.Arguments[0] is ForgeServerRegistryMessage);
@@ -73,7 +78,7 @@ namespace ForgeTests.ServerRegistry.Messaging.Interpreters
 				});
 			var interpreter = new GetServerRegistryInterpreter();
 			interpreter.Interpret(net, players[0].EndPoint, A.Fake<IMessage>());
-			A.CallTo(() => net.MessageBus.SendReliableMessage(A<IMessage>._, A<ISocket>._, A<EndPoint>._, 1000))
+			A.CallTo(() => net.MessageBus.SendReliableMessage(A<IMessage>._, A<ISocket>._, A<EndPoint>._, 0))
 				.MustHaveHappenedOnceExactly();
 		}
 	}


### PR DESCRIPTION
The recent changes for ForgeServerRegistryService, including NAT hole punching, include changes to core Alloy classes. This change updates the tests to match these changes.