### PR TITLE
Additional Message control and Message Pool statistics

### DIFF
--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/ForgeNetworkMediator.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/ForgeNetworkMediator.cs
@@ -108,11 +108,13 @@ namespace Forge.Networking
 			if (SocketFacade is ISocketServerFacade)
 			{
 				var itr = PlayerRepository.GetEnumerator();
+				message.StartSending();
 				while (itr.MoveNext())
 				{
 					if (itr.Current != null)
 						MessageBus.SendMessage(message, SocketFacade.ManagedSocket, itr.Current.EndPoint);
 				}
+				message.FinishSending();
 			}
 			else
 				MessageBus.SendMessage(message, SocketFacade.ManagedSocket, SocketFacade.ManagedSocket.EndPoint);

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/ForgePinger.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/ForgePinger.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Forge.Networking.Messaging;
 using Forge.Networking.Messaging.Messages;
 using Forge.Networking.Sockets;
 
@@ -40,7 +41,7 @@ namespace Forge.Networking
 
 		private void SendPingToServer(object state)
 		{
-			_networkMediator.MessageBus.SendMessage(new ForgePingMessage(),
+			_networkMediator.MessageBus.SendMessage(ForgeMessageCodes.Instantiate<ForgePingMessage>(),
 				_networkMediator.SocketFacade.ManagedSocket, _networkMediator.SocketFacade.ManagedSocket.EndPoint);
 		}
 	}

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessage.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessage.cs
@@ -1,4 +1,4 @@
-using Forge.Serialization;
+﻿using Forge.Serialization;
 
 namespace Forge.Networking.Messaging
 {
@@ -11,16 +11,41 @@ namespace Forge.Networking.Messaging
 		public abstract void Deserialize(BMSByte buffer);
 		public bool IsPooled { get; set; } = false;
 		public bool IsBuffered { get; set; } = false;
+		public bool IsQueued { get; set; } = false;
 		public bool IsSent { get; set; } = false;
+		public bool IsSending { get; set; } = false;
+
 
 		public virtual void Sent()
 		{
 			IsSent = true;
+			if (OnMessageSent == null)
+			{
+				int code = ForgeMessageCodes.GetCodeFromType(this.GetType());
+				if (code > 10 && code < 1000000000)
+					throw new System.Exception($"OnMessageSent is Null: {this.GetType()}");
+				return;
+			}
 			OnMessageSent?.Invoke(this);
 		}
 		public void Unbuffered()
         {
 			IsBuffered = false;
+			OnMessageSent?.Invoke(this);
+		}
+		public void Dequeued()
+		{
+			IsQueued = false;
+			Sent();
+		}
+
+		public void StartSending()
+		{
+			IsSending = true;
+		}
+		public void FinishSending()
+		{
+			IsSending = false;
 			OnMessageSent?.Invoke(this);
 		}
 

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageAttribute.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageAttribute.cs
@@ -46,4 +46,13 @@ namespace Forge.Networking.Messaging
 		public EngineMessageContractAttribute(int id, Type type)
 			: base(-id, type) { inputId = id; }
 	}
+
+	public sealed class EntityContractAttribute : MessageContractAttribute
+	{
+		public EntityContractAttribute(int id, Type type)
+			: base(id, type) { inputId = id; }
+
+		public int GetActionId() => base.id;
+		public Type GetActionClassType() => base.GetClassType();
+	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageBus.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageBus.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using System.Threading;
 using Forge.Factory;
 using Forge.Networking.Messaging.Messages;
@@ -81,6 +80,10 @@ namespace Forge.Networking.Messaging
 			var pageBuffer = _bufferPool.Get(page.Length);
 			pageBuffer.BlockCopy(buffer.byteArr, page.StartOffset, page.Length);
 			return pageBuffer;
+		}
+		public int GetRepeatBufferCount()
+		{
+			return _messageRepeater.GetRepeatBufferCount();
 		}
 
 		public IMessageReceiptSignature SendReliableMessage(IMessage message, ISocket sender, EndPoint receiver, int ttlMilliseconds = 0)

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageCodes.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageCodes.cs
@@ -69,5 +69,22 @@ namespace Forge.Networking.Messaging
 			_messageTypes.Clear();
 			_messageCodes.Clear();
 		}
+		public static List<int> AllMessageCodes()
+		{
+			List<int> codes = new List<int>();
+			foreach (var type in _messageTypes)
+			{
+				codes.Add(type.Key);
+			}
+			return codes;
+		}
+
+		public static List<PoolStats> GetPoolStats()
+		{
+			var stats = _messagePool.GetPoolStats();
+			foreach (var s in stats)
+				s.MessageId = _messageCodes[s.MessageType];
+			return stats;
+		}
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageRepeater.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageRepeater.cs
@@ -38,6 +38,14 @@ namespace Forge.Networking.Messaging
 		{
 			_messageRepository.RemoveMessage(sender, messageReceipt, recentPackets);
 		}
+		public int GetRepeatBufferCount()
+		{
+			return _messageRepository.GetMessageCount();
+		}
+		public double GetTTLDiff(EndPoint sender, IMessageReceiptSignature messageReceipt, int ttlMilliseconds)
+		{
+			return _messageRepository.GetTTLDiff(sender, messageReceipt, ttlMilliseconds);
+		}
 
 		public void RemoveAllFor(EndPoint receiver)
 		{

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageRepository.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageRepository.cs
@@ -4,7 +4,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Forge.Factory;
-using Forge.ForgeAlloyUnity.Assets.ForgeNetworking.Utilities;
+using Forge.Utilities;
 
 namespace Forge.Networking.Messaging
 {
@@ -277,6 +277,35 @@ namespace Forge.Networking.Messaging
 					}
 				}
 			}
+		}
+
+		public double GetTTLDiff(EndPoint sender, IMessageReceiptSignature receipt, int ttlMilliseconds)
+		{
+			double diff = -1;
+			lock (_messagesWithTTL)
+			{
+				for (int i = 0; i < _messagesWithTTL.Count; i++)
+				{
+					try
+					{
+						if (_messagesWithTTL[i].message.Receipt != null)  // Not sure why this happens
+						{
+							if (_messagesWithTTL[i].message.Receipt.Equals(receipt))
+							{
+								var span = new TimeSpan(0, 0, 0, 0, ttlMilliseconds);
+								diff = (DateTime.UtcNow - (_messagesWithTTL[i].ttl - span)).TotalMilliseconds;
+								break;
+							}
+						}
+					}
+					catch (Exception ex)
+					{
+						//UnityEngine.Debug.LogError($"GetTTLDiff: {receipt.ToString()}: {ex.Message}");
+					}
+				}
+
+			}
+			return diff;
 		}
 
 		public void Iterate(MessageRepositoryIterator iterator)

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessage.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessage.cs
@@ -1,4 +1,4 @@
-using Forge.Serialization;
+﻿using Forge.Serialization;
 
 namespace Forge.Networking.Messaging
 {
@@ -7,15 +7,91 @@ namespace Forge.Networking.Messaging
 	public interface IMessage
 	{
 		event MessageSent OnMessageSent;
+
+		/// <summary>
+		/// A unique Id to identify reliable messages
+		/// </summary>
 		IMessageReceiptSignature Receipt { get; set; }
+
+		/// <summary>
+		/// The method to call to process this message
+		/// </summary>
 		IMessageInterpreter Interpreter { get; }
+
+		/// <summary>
+		/// Serial the message data into the buffer
+		/// </summary>
+		/// <param name="buffer"></param>
 		void Serialize(BMSByte buffer);
+
+		/// <summary>
+		/// Deserialise the message data from the buffer
+		/// </summary>
+		/// <param name="buffer"></param>
 		void Deserialize(BMSByte buffer);
+
+		/// <summary>
+		/// This method should be called to confirm the message has been sent
+		/// This is defined on ForgeMessage and can be overriden on messages
+		/// Calls OnMessageSent
+		/// </summary>
 		void Sent();
+
+		/// <summary>
+		/// This method is called when the message is removed from a message repository, eg: ForgeMessageRepository
+		/// This is defined on ForgeMessage and can be overridden on messages
+		/// </summary>
 		void Unbuffered();
+
+		/// <summary>
+		/// This method is called when the message is removed from a waiting queue
+		/// It calls Sent()
+		/// </summary>
+		void Dequeued();
+
+		/// <summary>
+		/// True if message has been returned to the Pool
+		/// </summary>
 		bool IsPooled { get; set; }
+
+		/// <summary>
+		/// IsBuffered is true when the message is stored in a message repository
+		/// </summary>
 		bool IsBuffered { get; set; }
+
+		/// <summary>
+		/// IsQueued is true if the message is stored in a queue for processing
+		/// </summary>
+		bool IsQueued { get; set; }
+
+		/// <summary>
+		/// IsSent is true once the message has been transmitted.
+		/// IsSent can be true, while IsBuffered is also true. This happens when the message
+		/// is a reliable message and the sender is waiting for an Ack
+		/// </summary>
 		bool IsSent { get; set; }
+
+		/// <summary>
+		/// IsSending is true when the message is in the process of being sent
+		/// </summary>
+		bool IsSending { get; set; }
+
+		/// <summary>
+		/// Called when message starts to be sent
+		/// This is defined on ForgeMessage and can be overridden on messages
+		/// </summary>
+		void StartSending();
+
+		/// <summary>
+		/// Called when message has been sent
+		/// This is defined on ForgeMessage and can be overridden on messages
+		/// </summary>
+		void FinishSending();
+
+		/// <summary>
+		/// Resets fields on the message.
+		/// This should be defined on each message
+		/// </summary>
 		void Reset();
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageBus.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageBus.cs
@@ -13,5 +13,6 @@ namespace Forge.Networking.Messaging
 		void ReceiveMessageBuffer(ISocket readingSocket, EndPoint messageSender, BMSByte messageBuffer);
 		void SetMediator(INetworkMediator mediator);
 		void MessageConfirmed(EndPoint sender, IMessageReceiptSignature messageReceipt, ushort recentPackets);
+		int GetRepeatBufferCount();
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageRepeater.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageRepeater.cs
@@ -9,6 +9,8 @@ namespace Forge.Networking.Messaging
 		void AddMessageToRepeat(IMessage message, EndPoint receiver, int ttlMilliseconds = 0);
 		void RemoveRepeatingMessage(EndPoint sender, IMessageReceiptSignature messageReceipt, ushort recentPackets);
 		void RemoveAllFor(EndPoint receiver);
+		double GetTTLDiff(EndPoint sender, IMessageReceiptSignature messageReceipt, int ttlMilliseconds);
+		int GetRepeatBufferCount();
 		IMessageReceiptSignature GetNewMessageReceipt(EndPoint receiver);
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageRepository.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessageRepository.cs
@@ -13,8 +13,10 @@ namespace Forge.Networking.Messaging
 		void RemoveMessage(EndPoint sender, IMessageReceiptSignature receipt);
 		void RemoveMessage(EndPoint sender, IMessageReceiptSignature receipt, ushort recentPackets);
 		bool Exists(EndPoint sender, IMessageReceiptSignature receipt);
+		double GetTTLDiff(EndPoint sender, IMessageReceiptSignature receipt, int ttlMilliseconds);
 		void Iterate(MessageRepositoryIterator iterator);
 		void Clear();
+		int GetMessageCount();
 		ushort ProcessReliableSignature(EndPoint sender, int id);
 		IMessageReceiptSignature GetNewMessageReceipt(EndPoint receiver);
 

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IServerImmediate.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IServerImmediate.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Forge.Networking.Messaging
+{
+	/// <summary>
+	/// Identifies Interpreters that don't need to run on Synchronisation Context
+	/// </summary>
+	public interface IServerImmediate
+	{
+	}
+}

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/Interpreters/ForgePingInterpreter.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/Interpreters/ForgePingInterpreter.cs
@@ -1,10 +1,10 @@
-using System.Net;
+﻿using System.Net;
 
 namespace Forge.Networking.Messaging.Interpreters
 {
 	public class ForgePingInterpreter : IMessageInterpreter
 	{
-		public static ForgePingInterpreter Instance { get; private set; } = new ForgePingInterpreter();
+		public static ForgePingInterpreter Instance { get; set; } = new ForgePingInterpreter();
 
 		public bool ValidOnClient => false;
 		public bool ValidOnServer => true;
@@ -12,6 +12,7 @@ namespace Forge.Networking.Messaging.Interpreters
 		public void Interpret(INetworkMediator netContainer, EndPoint sender, IMessage message)
 		{
 			// Nothing to do here, we have already updated the player timestamp
+			message.Sent();
 		}
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/Interpreters/ForgeReceiptAcknowledgementInterpreter.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/Interpreters/ForgeReceiptAcknowledgementInterpreter.cs
@@ -3,7 +3,7 @@ using Forge.Networking.Messaging.Messages;
 
 namespace Forge.Networking.Messaging.Interpreters
 {
-	public class ForgeReceiptAcknowledgementInterpreter : IMessageInterpreter
+	public class ForgeReceiptAcknowledgementInterpreter : IMessageInterpreter, IServerImmediate
 	{
 		public bool ValidOnClient => true;
 		public bool ValidOnServer => true;

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/MessagePoolMulti.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/MessagePoolMulti.cs
@@ -7,7 +7,7 @@ namespace Forge.Networking.Messaging
 	public class MessagePoolMulti
 	{
 		private readonly Dictionary<Type, ConcurrentQueue<IMessage>> _messagePools = new Dictionary<Type, ConcurrentQueue<IMessage>>();
-
+		private readonly ConcurrentDictionary<Type, int> _poolSize = new ConcurrentDictionary<Type, int>();
 		public IMessage Get(Type t)
 		{
 			var pool = GetPool(t);
@@ -23,7 +23,8 @@ namespace Forge.Networking.Messaging
 					item.Receipt = null;
 					return item;
 				}
-				else return CreateNewMessageForPool(t, pool);
+				else
+					return CreateNewMessageForPool(t, pool);
 			}
 		}
 
@@ -42,7 +43,8 @@ namespace Forge.Networking.Messaging
 					item.Receipt = null;
 					return (T)item;
 				}
-				else return CreateNewMessageForPool<T>(pool);
+				else
+					return CreateNewMessageForPool<T>(pool);
 			}
 		}
 
@@ -52,14 +54,21 @@ namespace Forge.Networking.Messaging
 			{
 				pool = new ConcurrentQueue<IMessage>();
 				_messagePools.Add(type, pool);
+				_poolSize.TryAdd(type, 0);
 			}
 			return pool;
+		}
+
+		private void IncrementPool(Type type)
+		{
+			_poolSize.AddOrUpdate(type, 1, (key, oldvalue) => oldvalue + 1);
 		}
 
 		private T CreateNewMessageForPool<T>(ConcurrentQueue<IMessage> pool) where T : IMessage, new()
 		{
 			T m = new T();
 			m.OnMessageSent += Release;
+			IncrementPool(typeof(T));
 			return m;
 		}
 
@@ -67,18 +76,52 @@ namespace Forge.Networking.Messaging
 		{
 			IMessage m = (IMessage)Activator.CreateInstance(t);
 			m.OnMessageSent += Release;
+			IncrementPool(t);
 			return m;
 		}
 
 		private void Release(IMessage message)
 		{
-			if (message.IsPooled) return; // Message has already been returned to pool
-			if (!message.IsSent) return;	// Message has not been sent, not ready to return to pool
-			if (message.IsBuffered) return; // Message is still buffered, not ready to return to pool
+			if (message.IsPooled)
+				return; // Message has already been returned to pool
+			if (!message.IsSent)
+				return; // Message has not been sent, not ready to return to pool
+			if (message.IsBuffered)
+				return; // Message is still buffered, not ready to return to pool
+			if (message.IsQueued)
+				return; // Message is still queued, not ready to return to pool
+			if (message.IsSending)
+				return; // Message is still being sent, not ready to return to pool
 			message.IsSent = false;
 			message.IsPooled = true;
 			ConcurrentQueue<IMessage> pool = GetPool(message.GetType());
 			pool.Enqueue(message);
 		}
+
+		public List<PoolStats> GetPoolStats()
+		{
+			List<PoolStats> poolStats = new List<PoolStats>();
+
+			foreach (var p in _messagePools)
+			{
+				int size = _poolSize[p.Key];
+				poolStats.Add(new PoolStats()
+				{
+					MessageType = p.Key,
+					PoolSize = size,
+					PoolCount = p.Value.Count
+				});
+			}
+
+			return poolStats;
+		}
+	}
+
+	public class PoolStats
+	{
+		public Type MessageType { get; set; }
+		public int MessageId { get; set; }
+		public int PoolSize { get; set; } = 0;
+		public int PoolCount { get; set; } = 0;
 	}
 }

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Players/ForgePlayerRepository.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Players/ForgePlayerRepository.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 using Forge.Factory;
-using Forge.ForgeAlloyUnity.Assets.ForgeNetworking.Utilities;
+using Forge.Utilities;
 
 namespace Forge.Networking.Players
 {

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Sockets/ForgeUDPSocketFacadeBase.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Sockets/ForgeUDPSocketFacadeBase.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Net;
 using System.Threading;
-using Forge.ForgeAlloyUnity.Assets.ForgeNetworking.Utilities;
+using Forge.Utilities;
 using Forge.Serialization;
 
 namespace Forge.Networking.Sockets

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Sockets/ForgeUDPSocketServerFacade.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Sockets/ForgeUDPSocketServerFacade.cs
@@ -1,5 +1,5 @@
 ﻿using Forge.Factory;
-using Forge.ForgeAlloyUnity.Assets.ForgeNetworking.Utilities;
+using Forge.Utilities;
 using Forge.Networking.Messaging.Messages;
 using Forge.Networking.Players;
 using Forge.Serialization;

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Utilities/ConcurrentHashSet.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Utilities/ConcurrentHashSet.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 
-namespace Forge.ForgeAlloyUnity.Assets.ForgeNetworking.Utilities
+namespace Forge.Utilities
 {
 
 

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Utilities/ForgeExtensionscs.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Utilities/ForgeExtensionscs.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Text;
 
-namespace Forge.ForgeAlloyUnity.Assets.ForgeNetworking.Utilities
+namespace Forge.Utilities
 {
 	public static class ForgeExtensionscs
 	{

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Utilities/ForgeSynchronizationContext.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Utilities/ForgeSynchronizationContext.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading;
 
-namespace Forge.Networking.Utilities
+namespace Forge.Utilities
 {
 
     public sealed class ForgeSynchronizationContext : SynchronizationContext

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Utilities/GlobalConst.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Utilities/GlobalConst.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Forge.ForgeAlloyUnity.Assets.ForgeNetworking.Utilities
+﻿
+namespace Forge.Utilities
 {
 	public class GlobalConst
 	{

--- a/ForgeAlloyUnity/Assets/ForgeNetworking/Utilities/SampleUtil.cs
+++ b/ForgeAlloyUnity/Assets/ForgeNetworking/Utilities/SampleUtil.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
 
-namespace Forge.ForgeAlloyUnity.Assets.ForgeNetworking.Utilities
+namespace Forge.Utilities
 {
 	public class SampleUtil
 	{

--- a/ForgeSampleGame/ForgeSampleGame.cs
+++ b/ForgeSampleGame/ForgeSampleGame.cs
@@ -3,10 +3,9 @@ using System.Net;
 using System.Text;
 using Forge;
 using Forge.Factory;
-using Forge.ForgeAlloyUnity.Assets.ForgeNetworking.Utilities;
+using Forge.Utilities;
 using Forge.Networking;
 using Forge.Networking.Messaging;
-using Forge.Networking.Utilities;
 using Forge.ServerRegistry.DataStructures;
 using Forge.ServerRegistry.Messaging.Interpreters;
 using Forge.ServerRegistry.Messaging.Messages;
@@ -81,6 +80,7 @@ namespace ForgeSampleGame
 							case "?":
 								Console.WriteLine("Commands:");
 								Console.WriteLine("exit/quit             Stop this service");
+								Console.WriteLine("connect server		 Connects to server. Can be Id or IP");
 								Console.WriteLine("list                  List available servers");
 								Console.WriteLine("");
 								break;

--- a/ForgeSampleGameServer/ForgeSampleGameServer.cs
+++ b/ForgeSampleGameServer/ForgeSampleGameServer.cs
@@ -2,12 +2,9 @@
 using System.Text;
 using Forge;
 using Forge.Factory;
-using Forge.ForgeAlloyUnity.Assets.ForgeNetworking.Utilities;
+using Forge.Utilities;
 using Forge.Networking;
 using Forge.Networking.Players;
-using Forge.Networking.Sockets;
-using Forge.Networking.Utilities;
-using Forge.Serialization.Serializers;
 using Forge.ServerRegistry.Messaging.Interpreters;
 using ForgeSampleGameServer.Engine;
 using ForgeSampleGameServer.Messaging.Interpreters;

--- a/ForgeServerRegistryService/ForgeServerRegistryService.cs
+++ b/ForgeServerRegistryService/ForgeServerRegistryService.cs
@@ -2,11 +2,10 @@
 using System.Text;
 using Forge;
 using Forge.Factory;
-using Forge.ForgeAlloyUnity.Assets.ForgeNetworking.Utilities;
+using Forge.Utilities;
 using Forge.Networking;
 using Forge.Networking.Players;
 using Forge.Networking.Sockets;
-using Forge.Networking.Utilities;
 using Forge.ServerRegistry.Messaging.Interpreters;
 using ForgeServerRegistryService.Engine;
 using ForgeServerRegistryService.Messaging.Interpreters;
@@ -121,7 +120,8 @@ namespace ForgeServerRegistryService
 									while (itr.MoveNext())
 									{
 										var server = (RegisteredServer)itr.Current;
-										Console.WriteLine($"Server[{server.Id}] Name[{server.Name}] Players[{server.CurrentPlayers}/{server.MaxPlayers}]");
+										if (server.IsRegisteredServer)
+											Console.WriteLine($"Server[{server.Id}] Name[{server.Name}] Players[{server.CurrentPlayers}/{server.MaxPlayers}]");
 									}
 									Console.WriteLine("=== End Server List ===");
 									break;


### PR DESCRIPTION


ForgeMessage
- Added IsSending Property. When sending a message to all players, the IsSending property will block a message returning to the pool until message has been sent to all players.
- Added IsQueued Property. The IsQueue property will block the message returning to the pool. This is typically uses in the implementation of a locally hosted game may use a queue to pass messages between the server and the client. iMessage.Dequeued should be called after the client processes the message which will call IsSent and return the message to the pool.
- Throw an exception if the Sent method is called and OnMessageSent event is null.  This will occur if the message was instantiated outside of the pool.

ForgeMessageBus
- New method GetRepeatBufferCount that returns the number of messages in the buffer

ForgeMessageCodes
- New Method AllMessageCodes that returns a list of all available message codes
- New Method GetPoolStats that will return statistics on the message pool

In addition this update includes some code tidy up for previous changes.